### PR TITLE
Can we have the status value match the corresponding key where we can find more info?

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,16 +32,16 @@ conforms to the spec below.
    serialization or other fundamental code fails.
 
 0. The response __must__ contain a `"status"` key set either to `"ok"`
-   or `"fail"`.
+   or `"failures"`.
 
 0. The response __must__ contain a `"now"` key set to the current
    server's time in seconds since epoch as a string.
 
-0. If the `"status"` key is set to `"fail"`, the response __may__
+0. If the `"status"` key is set to `"failures"`, the response __may__
    contain a `"failures"` key set to an Array of string names
    representing failed checks.
 
-0. If the `"status"` key is set to `"fail"`, the response __may__
+0. If the `"status"` key is set to `"failures"`, the response __may__
    contain a `"timeouts"` key set to an Array of string names
    representing checks that exceeded an implementation-specific
    individual timeout.
@@ -59,7 +59,7 @@ conforms to the spec below.
   // These two keys will always exist.
 
   "now": "1359055102",
-  "status": "fail",
+  "status": "failures",
 
   // This key may only exist when a named check has failed.
 

--- a/lib/pinglish.rb
+++ b/lib/pinglish.rb
@@ -81,7 +81,7 @@ class Pinglish
 
       failed      = results.values.any? { |v| failure? v }
       http_status = failed ? 503 : 200
-      text_status = failed ? "fail" : "ok"
+      text_status = failed ? "failures" : "ok"
 
       data = {
         :now    => Time.now.to_i.to_s,
@@ -122,7 +122,7 @@ class Pinglish
     # and interpolate the current epoch time.
 
     now = Time.now.to_i.to_s
-    [500, HEADERS, ['{"status":"fail","now":"' + now + '"}']]
+    [500, HEADERS, ['{"status":"failures","now":"' + now + '"}']]
   end
 
   # Add a new check with optional `name`. A `:timeout` option can be


### PR DESCRIPTION
Pretty much what the subject says, but I think we should use:

``` javascript
{
  "status": "failures",
  "failures": ["db"]
}
```

This way we can extend this with additional functionality in the future. This also takes away any guessing. Linking the value to keys like this is really powerful (we used to use this at Heroku).
