### PR TITLE
Use /_status instead of /_ping

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 # Pinglish
 
 A simple Rack middleware for checking application health. Pinglish
-exposes a `/_ping` resource via HTTP `GET`, returning JSON that
+exposes a `/_status` resource via HTTP `GET`, returning JSON that
 conforms to the spec below.
 
 ## The Spec
 
-0. The application __must__ respond to `GET /_ping` as an HTTP request.
+0. The application __must__ respond to `GET /_status` as an HTTP request.
 
 0. The request handler __should__ check the health of all services the
-  application depends on, answering questions like, "Can I query
-  agains my MySQL database," "Can I create/read keys in Reds," or "How
-  many docs are in my ElasticSearch index?"
+   application depends on, answering questions like, "Can I query
+   agains my MySQL database," "Can I create/read keys in Reds," or "How
+   many docs are in my ElasticSearch index?"
 
 0. The response __must__ return within 29 seconds. This is one second
    less than the default timeout for many monitoring services.

--- a/lib/pinglish.rb
+++ b/lib/pinglish.rb
@@ -1,7 +1,7 @@
 require "json"
 require "timeout"
 
-# This Rack middleware provides a "/_ping" endpoint for configurable
+# This Rack middleware provides a "/_status" endpoint for configurable
 # system health checks. It's intended to be consumed by machines.
 
 class Pinglish
@@ -47,12 +47,12 @@ class Pinglish
   class TooLong < RuntimeError; end
 
   # Create a new instance of the middleware wrapping `app`, with an
-  # optional `path` (the default is `"/_ping"`) and behavior `block`.
+  # optional `path` (the default is `"/_status"`) and behavior `block`.
 
   def initialize(app, path = nil, &block)
     @app    = app
     @checks = {}
-    @path   = path || "/_ping"
+    @path   = path || "/_status"
 
     yield self if block_given?
   end

--- a/pinglish.gemspec
+++ b/pinglish.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |gem|
   gem.authors       = ["John Barnette", "Will Farrington"]
   gem.email         = ["jbarnette@github.com", "wfarr@github.com"]
   gem.description   = "A simple Rack middleware for checking app health."
-  gem.summary       = "/_ping your way to freedom."
+  gem.summary       = "ping your way to freedom."
   gem.homepage      = "https://github.com/jbarnette/pinglish"
 
   gem.files         = `git ls-files`.split $/


### PR DESCRIPTION
I didn't realize this was being developed and I asked this question on another issue (that I can't seem to find right now). `/_ping` doesn't properly reflect the functionality of this middleware. We aren't performing a simple ping, I think `/_status` is a bit clearer as to what we are providing.

This isn't a huge deal, I just think while we are this early in the development of tools like this we should make them clear and remove any sort of confusion early on. If people don't think it's worth changing, that's fine. If they do, I'll send a PR.
