### PR TITLE
Update README: Checks that return false are failures.

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,9 +107,13 @@ use Pinglish do |ping|
   end
 
   # Signal check failure by raising an exception. Any exception will do.
-
   ping.check :fails do
     raise "Everything's ruined."
+  end
+
+  # Additionally, any check that returns false is counted as a failure.
+  ping.check :false_fails do
+    false
   end
 end
 ```


### PR DESCRIPTION
I was surprised to find out that checks that return `false` are counted as failures. Looking in the closed issue history, #7 implements this, so the README should reflect that.
