### PR TITLE
Use path_info instead of path to match /_ping

### DIFF
--- a/lib/pinglish.rb
+++ b/lib/pinglish.rb
@@ -39,7 +39,7 @@ class Pinglish
   def call(env)
     request = Rack::Request.new env
 
-    return @app.call env unless request.path == @path
+    return @app.call env unless request.path_info == @path
 
     groups = [].map(&:to_s) # FIX
 

--- a/test/pinglish_test.rb
+++ b/test/pinglish_test.rb
@@ -138,6 +138,20 @@ class PinglishTest < MiniTest::Unit::TestCase
     assert_equal ["long"], json["timeouts"]
   end
 
+  def test_with_script_name
+    app = build_app
+
+    session = Rack::Test::Session.new(app)
+    session.get "/_ping", {}, "SCRIPT_NAME" => "/myapp"
+    assert_equal 200, session.last_response.status
+    assert_equal "application/json; charset=UTF-8",
+      session.last_response.content_type
+
+    json = JSON.load(session.last_response.body)
+    assert json.key?("now")
+    assert_equal "ok", json["status"]
+  end
+
   def test_with_custom_path
     app = build_app(:path => "/_piiiiing")
 


### PR DESCRIPTION
[path](http://rack.rubyforge.org/doc/Rack/Request.html#method-i-path) includes [script_name](http://rack.rubyforge.org/doc/Rack/Request.html#method-i-script_name) which means that if an app's root is `example.com/app`, `example.com/app/_ping` won't work by default. Checking against [path_info](http://rack.rubyforge.org/doc/Rack/Request.html#method-i-path_info) excludes the script name which means that it will check `/_ping` against the app root instead of the domain.

So if the app is hosted at `app.example.com`, `app.example.com/_ping` will work by default, and if the app is hosted at `example.com/app`, `example.com/app/_ping` will work as well.
