### PR TITLE
bugfix: wrap all checks with the provided `max`

### DIFF
--- a/lib/pinglish.rb
+++ b/lib/pinglish.rb
@@ -42,7 +42,7 @@ class Pinglish
     return @app.call env unless request.path_info == @path
 
     begin
-      timeout @timeout do
+      timeout @max do
         results  = {}
 
         @checks.values.each do |check|


### PR DESCRIPTION
`@timeout` is `nil` in this context.  And it turns out, `Timeout.timeout(nil)` does not raise an error. Instead, it helpfully shortcircuits and the block is called with no timeout protection.
