### PR TITLE
Fix potential conflict with surrounding middlewares

### DIFF
--- a/lib/pinglish.rb
+++ b/lib/pinglish.rb
@@ -87,7 +87,7 @@ class Pinglish
           end
         end
 
-        [http_status, HEADERS, [JSON.generate(data)]]
+        [http_status, HEADERS.dup, [JSON.generate(data)]]
       end
 
     rescue Exception => ex
@@ -97,7 +97,7 @@ class Pinglish
       # and interpolate the current epoch time.
 
       now = Time.now.to_i.to_s
-      [500, HEADERS, ['{"status":"failures","now":"' + now + '"}']]
+      [500, HEADERS.dup, ['{"status":"failures","now":"' + now + '"}']]
     end
   end
 


### PR DESCRIPTION
Other middlewares can modify headers directly. It would lead to incorrect value of HEADERS.
An example would be https://github.com/rack/rack/blob/master/lib/rack/etag.rb#L32.

In my case, that was the reason why pinglish middleware was returning the stale response.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/jbarnette/pinglish/17)

<!-- Reviewable:end -->
