### PR TITLE
Make Rack env available in ping check

### DIFF
--- a/lib/pinglish.rb
+++ b/lib/pinglish.rb
@@ -48,7 +48,7 @@ class Pinglish
         @checks.values.each do |check|
           begin
             timeout check.timeout do
-              results[check.name] = check.call
+              results[check.name] = check.call env
             end
           rescue StandardError => e
             results[check.name] = e

--- a/test/pinglish_test.rb
+++ b/test/pinglish_test.rb
@@ -155,6 +155,18 @@ class PinglishTest < MiniTest::Unit::TestCase
     assert_equal "failures", json["status"]
   end
 
+  def test_with_check_with_env
+    app = build_app do |ping|
+      ping.check(:with_env) { |env| env.fetch('PATH_INFO') }
+    end
+
+    session = Rack::Test::Session.new(app)
+    session.get "/_ping"
+
+    json = JSON.load(session.last_response.body)
+    assert_equal "/_ping", json["with_env"]
+  end
+
   def test_with_script_name
     app = build_app
 


### PR DESCRIPTION
Forward `env` to check block for more context. I need this so that `newrelic_rpm` transactions are properly instrumented.
